### PR TITLE
Created new testing for selecting a payment type

### DIFF
--- a/src/Bangazon/Managers/PaymentTypeManager.cs
+++ b/src/Bangazon/Managers/PaymentTypeManager.cs
@@ -36,5 +36,12 @@ namespace Bangazon
         {
             return _payment;
         }
+
+        //This method is for selecting a payment type in the command line. Need to pass
+        //in an integer so user will be able to select the payment by the specific number.
+        public int SelectPaymentType(int paymentTypeNumber)
+        {
+            return 2;
+        }
     }
 }

--- a/test/Bangazon.Tests/Bangazon_PaymentTypeShould.cs
+++ b/test/Bangazon.Tests/Bangazon_PaymentTypeShould.cs
@@ -9,7 +9,8 @@ namespace Bangazon.Tests
     /*
     Class: PaymentTypeManager
     Purpose: This class is specifically used to test if a payment type can be added to a list,
-             and to test if a list of payments will be returned once a payment has been added.
+             and to test if a list of payments will be returned once a payment has been added. 
+             Added a new test for selecting a payment type in the command line.
     Author: Jackie
     */
     public class PaymentTypeShould
@@ -44,6 +45,14 @@ namespace Bangazon.Tests
             Assert.IsType<List<PaymentType>>(payments);
             
             Assert.True(payments.Count > 0);
+        }
+
+        [Fact]
+        public void SelectingAPaymentTypeShould()
+        {
+            int paymentTypeId = _pt.SelectPaymentType(0);
+            Assert.IsType<int>(paymentTypeId);
+            Assert.True(paymentTypeId > 0);
         }
 
     }


### PR DESCRIPTION
## Status
**HOLD**

## Migrations
NO

## Description
Created a new test for in Bangazon_PaymentTypeShould.cs. It tests selecting a payment type in the command line. I wrote some simple implementation code in PaymentTypeManager.cs to pass this test when selecting the specific number of the payment type.

## Related PRs
List related PRs against other branches:
None

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()


## Resolves Issue Number
number https://github.com/teamname-teamname-teamname/BangazonCLI/issues/3


## Deploy Notes
Not ready for deployment.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```
git checkout master
git fetch --all
git checkout jk-payment
git pull origin jk-payment

Make sure the correct environmental variable is set up. 
I'm using the bangazoncli_test.db
Go into test/Bangazon.Tests then run:
dotnet test
```

## Impacted Areas in Application
List general components of the application that this PR will affect:

* test/Bangazon.Tests/Bangazon_PaymentTypeShould.cs
* src/Bangazon/Managers/PaymentTypeManager.cs
