### PR TITLE
Able to insert payment type into database and add payment type to list

### DIFF
--- a/src/Bangazon/Managers/PaymentTypeManager.cs
+++ b/src/Bangazon/Managers/PaymentTypeManager.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using Bangazon.Models;
 using Microsoft.Data.Sqlite;
 
-namespace Bangazon
+namespace Bangazon.Managers
 {
 
     /*
@@ -16,6 +16,7 @@ namespace Bangazon
     public class PaymentTypeManager
     {
         private List<PaymentType> _payment = new List<PaymentType>();
+        
         private DatabaseInterface _db;
 
         public PaymentTypeManager(DatabaseInterface db)
@@ -23,14 +24,15 @@ namespace Bangazon
             _db = db;
         }
 
-        //This method will add a payment to a list of Payment Types then return the list with added Payment Type.
-           public List<PaymentType> AddPaymentToList (PaymentType payment) 
+        //This method will add a payment to the database and add a payment type to a list, then return the paymentTypeId.
+           public int AddPayment (PaymentType payment) 
         {
+            int id = _db.Insert($"INSERT INTO paymentType values(null, '{payment.Name}', '{payment.CustomerId}', '{payment.AccountNumber}')");
+            payment.id = id;
             _payment.Add(payment);
-            
-            return _payment;
+            return id;
         }
-        
+
         //This method will return the list of payments types.
         public List<PaymentType> getListOfPayments()
         {

--- a/test/Bangazon.Tests/Bangazon_PaymentTypeShould.cs
+++ b/test/Bangazon.Tests/Bangazon_PaymentTypeShould.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Bangazon.Models;
 using Xunit;
+using Bangazon.Managers;
 
 namespace Bangazon.Tests
 {
@@ -10,10 +11,11 @@ namespace Bangazon.Tests
     Class: PaymentTypeManager
     Purpose: This class is specifically used to test if a payment type can be added to a list,
              and to test if a list of payments will be returned once a payment has been added. 
-             Added a new test for selecting a payment type in the command line.
+             Added a new test for selecting a payment type in the command line. Created a Dispose
+             method to delete all payment types being added to the database for testing purposes.
     Author: Jackie
     */
-    public class PaymentTypeShould
+    public class PaymentTypeShould : IDisposable
     {
         private readonly PaymentTypeManager _pt;
         private readonly DatabaseInterface _db;
@@ -29,23 +31,31 @@ namespace Bangazon.Tests
         public void AddPaymentTypeShould()
         {
             PaymentType payment = new PaymentType();
-
-            List<PaymentType> result = _pt.AddPaymentToList(payment);
-
-            Assert.Contains(payment, result);
-        }
-        
-        [Fact]
-        public void GetPaymentTypeListShould()
-        {
-            _pt.AddPaymentToList(new PaymentType());
-            
             List<PaymentType> payments = _pt.getListOfPayments();
+
+            int result = _pt.AddPayment(payment);
+
+            Assert.IsType<int>(result);
             
-            Assert.IsType<List<PaymentType>>(payments);
-            
+            foreach (PaymentType item in payments)
+            {
+                Assert.IsType<PaymentType>(item);
+            }
+        
             Assert.True(payments.Count > 0);
         }
+     
+        [Fact]
+        public void GetPaymentTypeListShould()
+         {
+             _pt.AddPayment(new PaymentType());
+             
+             List<PaymentType> payments = _pt.getListOfPayments();
+             
+             Assert.IsType<List<PaymentType>>(payments);
+    
+             Assert.True(payments.Count > 0);
+         }
 
         [Fact]
         public void SelectingAPaymentTypeShould()
@@ -55,5 +65,9 @@ namespace Bangazon.Tests
             Assert.True(paymentTypeId > 0);
         }
 
+        public void Dispose()
+        {
+            _db.Delete("DELETE FROM paymentType");
+        }
     }
 }


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Migrations
NO

## Description
In PaymentTypeManager.cs, I've changed some implementation code to actually insert payment type into the test database. The payment type will also be added to a list. In Bangazon_PaymentTypeShould.cs, I've refactored AddPaymentTypeShould to pass the test. I'm also calling IDisposable and deleting all the testing data that has been added to the database.

## Related PRs
List related PRs against other branches:
None

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()


## Resolves Issue Number
number https://github.com/teamname-teamname-teamname/BangazonCLI/issues/3


## Deploy Notes
Not ready for deployment.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```
git checkout master
git fetch --all
git checkout jk-payRefactor
git pull origin jk-payRefactor

After pulling down my branch to test, run dotnet test
```

## Impacted Areas in Application
List general components of the application that this PR will affect:

* src/Bangazon/Managers/PaymentTypeManger.cs
* test/Bangazon.Tests/Bangazon_PaymentTypeShould.cs
